### PR TITLE
Remove float from .column on screens <=640px

### DIFF
--- a/grid.css
+++ b/grid.css
@@ -435,6 +435,7 @@ img {
   .column.one-fourth {
     margin: 2em 0 0 0;
     width: 100%;
+    float: none;
   }
 
   .column:first-child { margin-top: 0; }


### PR DESCRIPTION
It doesn't make much difference since it has `width: 100%;`, but I needed `<hr>` between columns on <=640px screens, and that `<hr>` is visible only on those screens, removing float allowed me to use margins correctly on `<hr>` element to set some spacing between elements.
