### PR TITLE
Add IE8 polyfills

### DIFF
--- a/index.html
+++ b/index.html
@@ -272,8 +272,10 @@
           issues. Rows are cleared with either a <code>clearfix</code> or <code>overflow: hidden</code>. This clearfix was
           created by <a href="http://nicolasgallagher.com/micro-clearfix-hack/" target="_blank">Nicolas Gallagher</a>:</p>
           <hr>
-          <script src="https://gist.github.com/aekaplan/8467436.js"></script>
+          <script src="https://gist.github.com/anonymous/8971398.js"></script>
+          <p>~OR~</p>
           <script src="https://gist.github.com/aekaplan/8467460.js"></script>
+          <hr>
           <script src="https://gist.github.com/aekaplan/8430571.js"></script>
         </div>
       </section>


### PR DESCRIPTION
I know that supporting IE8 is not the most popular activity, but doing so in this case comes at very little cost: since the js links are inside a conditional comment, they will not get loaded by non-IE8 browsers, and since I linked to a CDN there is no need to place any additional files on your server.
