### PR TITLE
Work around a font size flicker bug Safari

### DIFF
--- a/grid.css
+++ b/grid.css
@@ -15,11 +15,11 @@ html {
 }
 
 @media (min-width: 40rem) {
-  html { font-size: 112%; }
+  body { font-size: 112%; }
 }
 
 @media (min-width: 64rem) {
-  html { font-size: 120%; }
+  body { font-size: 120%; }
 }
 
 body {


### PR DESCRIPTION
When the font-size is defined on html instead of body, Safari 7 flickers
the font size back and forth when resizing around each font-size change.

Easy workaround is to change the font-size on body instead. I did not look into why this happens because other browsers don't do this, so it just seems like a bug in Safari 7.

Video: http://youtu.be/_36K18JheP4

**Steps to reproduce**
- Visit http://samhuri.net/f/grid-bug.html in Safari 7 on a Mac
- Resize your browser window enough to cross a size boundary, 40rem or 64rem

You can check out http://samhuri.net to see the fix applied.
